### PR TITLE
Fix spelling mistakes and remove trailing whitespaces

### DIFF
--- a/hsvba
+++ b/hsvba
@@ -7434,7 +7434,7 @@ __struct__parse( \
     # +-|-+---+   +-|-+---+   +-|-+---+   +-|-+---+       +---+---+
     #   v           v           v           v
     #  <integer>  <map>       <map>       <map>
-    #  n_params   binded      rmap      attribute
+    #  n_params   bounded     rmap      attribute
     #
     #
     # layout of struct
@@ -7445,8 +7445,8 @@ __struct__parse( \
     #    |      <int>      |  count of parameters
     #    |     n_params    |  3
     #    +-----------------+
-    #    |      <map>      |  binded arguments
-    #    |      binded     |  {1:5, 2:3}
+    #    |      <map>      |  bounded arguments
+    #    |      bounded    |  {1:5, 2:3}
     #    +-----------------+
     #    |      <map>      |  reverse index
     #    |      rmap       |  {arg1:1, arg2:2, arg3:3}
@@ -8215,8 +8215,8 @@ __struct__parse( \
 #    |      <int>      |  count of parameters
 #    |     n_params    |  3
 #    +-----------------+
-#    |      <map>      |  binded arguments
-#    |      binded     |  {1:5, 2:3}
+#    |      <map>      |  bounded arguments
+#    |      bounded    |  {1:5, 2:3}
 #    +-----------------+
 #    |      <map>      |  reverse parameter map
 #    |      rmap       |  {arg1:1, arg2:2, arg3:3}
@@ -8281,8 +8281,8 @@ struct__type__init( \
     }
 
     __struct__type__M_n_params      = 0;
-    __struct__type__M_binded_num    = 1;
-    __struct__type__M_binded_path   = 2;
+    __struct__type__M_bounded_num   = 1;
+    __struct__type__M_bounded_path  = 2;
     __struct__type__M_rmap          = 3;
     __struct__type__M_members       = 4;
 
@@ -8305,11 +8305,11 @@ struct__type__init( \
 #    |      <int>      |  count of parameters
 #    |     n_params    |  3
 #    +-----------------+
-#    |      <map>      |  binded number arguments
-#    |    binded_num   |  {1:5, 2:3}
+#    |      <map>      |  bounded number arguments
+#    |    bounded_num  |  {1:5, 2:3}
 #    +-----------------+
-#    |      <map>      |  binded path arguments
-#    |    binded_path  |  {4:./a/b/c}
+#    |      <map>      |  bounded path arguments
+#    |    bounded_path |  {4:./a/b/c}
 #    +-----------------+
 #    |      <map>      |  reverse index
 #    |      rmap       |  {arg1:1, arg2:2, arg3:3, arg4:4}
@@ -8332,24 +8332,24 @@ struct__type__new(    _p, _type, _v) {
         return addr__C_NIL;
     }
 
-    # binded_num
+    # bounded_num
     _v = map__new();
     if (_v == addr__C_NIL) {
         return (-1);
     }
 
-    addr__set(_type + __struct__type__M_binded_num, _v);
+    addr__set(_type + __struct__type__M_bounded_num, _v);
     if (addr__errno < 0) {
         return addr__C_NIL;
     }
 
-    # binded_path
+    # bounded_path
     _v = map__new();
     if (_v == addr__C_NIL) {
         return (-1);
     }
 
-    addr__set(_type + __struct__type__M_binded_path, _v);
+    addr__set(_type + __struct__type__M_bounded_path, _v);
     if (addr__errno < 0) {
         return addr__C_NIL;
     }
@@ -8411,7 +8411,7 @@ function \
 struct__type__bind_num( \
     type, v, \
     \
-    _n, _binded, _status \
+    _n, _bounded, _status \
 ) {
     _n = addr__deref(type + __struct__type__M_n_params) + 1;
     if (addr__errno < 0) {
@@ -8423,12 +8423,12 @@ struct__type__bind_num( \
         return _status;
     }
 
-    _binded = addr__deref(type + __struct__type__M_binded_num);
+    _bounded = addr__deref(type + __struct__type__M_bounded_num);
     if (addr__errno < 0) {
         return addr__errno;
     }
 
-    _status = map__insert(_binded, _n, v);
+    _status = map__insert(_bounded, _n, v);
     if (_status < 0) {
         return (-1);
     }
@@ -8442,7 +8442,7 @@ function \
 struct__type__bind_path( \
     type, v, \
     \
-    _n, _binded, _status \
+    _n, _bounded, _status \
 ) {
     _n = addr__deref(type + __struct__type__M_n_params) + 1;
     if (addr__errno < 0) {
@@ -8454,12 +8454,12 @@ struct__type__bind_path( \
         return _status;
     }
 
-    _binded = addr__deref(type + __struct__type__M_binded_path);
+    _bounded = addr__deref(type + __struct__type__M_bounded_path);
     if (addr__errno < 0) {
         return addr__errno;
     }
 
-    _status = map__insert(_binded, _n, v);
+    _status = map__insert(_bounded, _n, v);
     if (_status < 0) {
         return (-1);
     }

--- a/hsvba
+++ b/hsvba
@@ -159,7 +159,7 @@
 #    so the external command "base64" is required.
 #
 #    +=====================================================================+
-#    | AWK implementation       | base64 requeirement | result             |
+#    | AWK implementation       | base64 requirement  | result             |
 #    +=====================================================================+
 #    | bwk(nawk,onetrueawk)     | requires            | works(slow)        |
 #    +--------------------------+---------------------+--------------------+
@@ -279,11 +279,11 @@
 #
 #    [ECMA-376 Part1]
 #        ECMA-376, 5th Edition Office Open XML File Formats - Fundamentals And Markup Language Reference
-#        https://ecma-addrational.org/publications-and-standards/standards/ecma-376/
+#        https://ecma-international.org/publications-and-standards/standards/ecma-376/
 #
 #    [ECMA-376 Part2]
 #        ECMA-376, 5th Edition Office Open XML File Formats - Open Packaging Conventions
-#        https://ecma-addrational.org/publications-and-standards/standards/ecma-376/
+#        https://ecma-international.org/publications-and-standards/standards/ecma-376/
 #
 #    [pcodedump]
 #        Vesselin Bontchev, A VBA p-code disassembler.
@@ -606,7 +606,7 @@ str__init() {
     # quick & dirty latin1 -> utf-8 conversion (printable only)
     for (_i = 0; _i <= 255; ++_i) {
         if (_i < 32) {
-            # C1 charactors
+            # C1 characters
             str__debug_chr[_i] = sprintf("<%02X>", _i);
         } else if (_i < 127) {
             # ASCII
@@ -882,7 +882,7 @@ stream__longjmp(stream, jmp_buf) {
     stream[__stream__M_iit] = jmp_buf[1];
 }
 # }}}
-# {{{ steram::rsearch
+# {{{ stream::rsearch
 function \
 stream__rsearch( \
     stream, word, \
@@ -1045,7 +1045,7 @@ stream__read_uint64(stream,    _n, _i, _o, _iit) {
     return _o;
 }
 # }}}
-# {{{ steram::read_raw_string
+# {{{ stream::read_raw_string
 function \
 stream__read_raw_string(stream, size,    _iit, _it_end, _o) {
 
@@ -1188,7 +1188,7 @@ stream__read_timestamp( \
 }
 # }}}
 # {{{ stream::read_ansi_string
-# OEM/DBCS bytearry -> UTF-8 string conversion
+# OEM/DBCS bytearray -> UTF-8 string conversion
 function \
 stream__read_ansi_string( \
     stream, size, terminator, \
@@ -2588,7 +2588,7 @@ function __map__fixup( \
                     #           /   \    /   \                      /   \
                     #
 
-                    # rotation patern LL
+                    # rotation pattern LL
                     # get p3
 
                     # change the color of node to black
@@ -2736,7 +2736,7 @@ function __map__fixup( \
                     #          /   \   /   \
                     #
 
-                    # rotation patern LR
+                    # rotation pattern LR
                     # get p3
                     # change the color of p1 to black
                     _status = addr__set(_p1 + map__M_color, map__C_color_black);
@@ -2927,7 +2927,7 @@ function __map__fixup( \
                     #
                     #
 
-                    # rotation patern RL
+                    # rotation pattern RL
                     # get p3
                     # {{{
 
@@ -3111,7 +3111,7 @@ function __map__fixup( \
                     #            /   \    /   \                     /   \
                     #
 
-                    # rotation patern RR
+                    # rotation pattern RR
                     # get p3
                     # {{{
 
@@ -5023,7 +5023,7 @@ __atom__cell_pretty_print( \
                indent "    " _rhs " -> " addr__deref(_rhs) "\n" \
         ;
     }
-    return "unkonwn, tag: " _tag ", " cell;
+    return "unknown, tag: " _tag ", " cell;
 }
 # }}}
 # {{{ (private)::atom::type::new
@@ -5072,14 +5072,14 @@ __atom__type_new( \
 #
 # Size:
 #   An integer size if D(SizeIsParameterized) is 0.
-#   Otherwize, this is a GOT address of ParameterizedFormat.
+#   Otherwise, this is a GOT address of ParameterizedFormat.
 #       Integer: byte or bit size
 #       Float: must be 4
 #       String: byte size of a string
 #
 # FormatID:
 #   Reference index of format string if D(SizeIsParameterized) is 0.
-#   Otherwize, this is a GOT address of ParameterizedFormat.
+#   Otherwise, this is a GOT address of ParameterizedFormat.
 #
 # Encoding:
 #
@@ -5348,7 +5348,7 @@ __atom__instantiate( \
     _lhs, _rhs, _v, _params, \
     _size, _sizeunit, _encoding, _base \
 ) {
-    # test if atomname is a concreate type
+    # test if atomname is a concrete type
     if (atomname ".base" in __atom__S_type) {
         return (1);
     }
@@ -5616,7 +5616,7 @@ __atom__eval( \
 #    token ID
 #
 # Position (16 bits):
-#    poistion in source
+#    position in source
 #
 # Piece ID (16 bits):
 #    reference of a piece string
@@ -5738,7 +5738,7 @@ astore__init(    _i, _status) {
     #
     # This protocol references commonly used data types as defined in [MS-DTYP].
     # An LCID is a 4-byte value. The value supplied in an LCID is a standard
-    # numeric substitution for the addrational [RFC5646] string.
+    # numeric substitution for the international [RFC5646] string.
     # The following diagram is shown in host byte order.
     #
     # +===============================================================+
@@ -7061,7 +7061,7 @@ struct__declare( \
 #    token ID
 #
 # Position (22 bits):
-#    the poistion in source
+#    the position in source
 #
 # Piece ID (22 bits):
 #    a GOT reference of a piece string
@@ -7466,7 +7466,7 @@ __struct__parse( \
     #
     # member = <identifier> "::" <type> [ <options> ] ;
     #
-    # options = <option> | <optioins> ;
+    # options = <option> | <options> ;
     #
     # options = "exists" , "only", "if", <expression>
     #         | "aligned", "on", <digits>
@@ -7500,12 +7500,12 @@ __struct__parse( \
     #                    , { ( "+" | "-" ) , <multiplicativeExpression> }
     #                    ;
     #
-    # multiplicativeExpression := <uneryExpression>
-    #                          , { ( "*" | "/" | "%" ) , <uneryExpression> }
+    # multiplicativeExpression := <unaryExpression>
+    #                          , { ( "*" | "/" | "%" ) , <unaryExpression> }
     #                          ;
     #
-    # uneryExpression := <primaryExpression>
-    #                  | { ( "+" | "-" | "not" ) , <uneryExpression> } ;
+    # unaryExpression := <primaryExpression>
+    #                  | { ( "+" | "-" | "not" ) , <unaryExpression> } ;
     #
     # primaryExpression := <variable>
     #                   |  <path>
@@ -8242,7 +8242,7 @@ __struct__parse( \
 #    |   type_params   |
 #    +-----------------+
 #    |     <list>      |
-#    |   varidators    |
+#    |   validators    |
 #    +-----------------+
 #
 # layout of header
@@ -9287,7 +9287,7 @@ __acp__decode_charmap( \
 # '}'
 function \
 __acp__build_map_874_to_u8char() {
-    # cp873 charactor mappings
+    # cp873 character mappings
     split( \
         "\342\202\254 ? ? ? ? \342\200\246 ? ? ? ? ? ? ? ? ? ? ? \342\200\230 \342\200\231 \342\200\234 " \
         "\342\200\235 \342\200\242 \342\200\223 \342\200\224 ? ? ? ? ? ? ? ? \302\240 " \
@@ -9351,7 +9351,7 @@ __acp__build_map_874_to_u8char() {
 # '}'
 function \
 __acp__build_map_932_to_u8char() {
-    # cp932 charactor mappings
+    # cp932 character mappings
     # '${__pp__enable_multibyte:+'
     __acp__decode_charmap(acp__S_charmap, \
         "44CALOOAgSzjgIIs77yMLO+8jizjg7ss77yaLO+8myzvvJ8s77yBLOOCmyzjgpwswrQ" \
@@ -10182,7 +10182,7 @@ __acp__build_map_932_to_u8char() {
 # '}'
 function \
 __acp__build_map_936_to_u8char() {
-    # cp936 charactor mappings
+    # cp936 character mappings
     # '${__pp__enable_multibyte:+'
     __acp__decode_charmap(acp__S_charmap, \
         "5LiCLOS4hCzkuIUs5LiGLOS4jyzkuJIs5LiXLOS4nyzkuKAs5LihLOS4oyzkuKYs5Li" \
@@ -20584,7 +20584,7 @@ __vba__dirstream__unpack_project_information_version( \
     #   In versions up to Office2000, this timestamp is the number of
     #   seconds since January 1, 1970, 00:00:00, i.e. the UNIX epoch.
     #
-    #   However, in Office XP (2001) and later, the begginning of this
+    #   However, in Office XP (2001) and later, the beginning of this
     #   epoch seems to have changed to November 21, 1968, 00:00:00.
     #
     # * Why "November 21, 1968"?
@@ -21272,7 +21272,7 @@ __vba__dirstream__unpack_project_references_reference_project( \
 # +---------------------------------------------------------------+
 # |                              ...                              |
 # +---------------------------------------------------------------+
-# |                      Moducles (variable)                      |
+# |                      Modules (variable)                       |
 # +---------------------------------------------------------------+
 # |                              ...                              |
 # +---------------------------------------------------------------+
@@ -21411,7 +21411,7 @@ __vba__dirstream__unpack_project_modules_cookie( \
 # +-------------------------------+-------------------------------+
 # |                              ...                              |
 # +---------------------------------------------------------------+
-# |                    PrivateRecord (optinal)                    |
+# |                    PrivateRecord (optional)                   |
 # +-------------------------------+-------------------------------+
 # |             ...               |     Terminator (2 bytes)      |
 # +-------------------------------+-------------------------------+
@@ -23586,7 +23586,7 @@ vba__projectstream__unpack_encrypteddata( \
 # |                    1                   2                   3  |
 # |0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1|
 # +===============================================================+
-# |   Reserved    |GrbitKe|             GrbithashNull             |
+# |   Reserved    |GrbitKe|             GrbitHashNull             |
 # +---------------+-------+---------------------------------------+
 # |                          KeyNoNulls                           |
 # +---------------------------------------------------------------+
@@ -23991,7 +23991,7 @@ __vba__vbaprojectstream__unpack_cache( \
         return __vba__vbaprojectstream__E_UNEXPECTED;
     }
 
-    # *Unknonwn3 (2 bytes)
+    # *Unknown3 (2 bytes)
     _v = stream__read_uint16(stream);
     if (astore__set(store, "*Unknown3::hexint16", _v) < 0) {
         return __vba__vbaprojectstream__E_UNEXPECTED;
@@ -24022,13 +24022,13 @@ __vba__vbaprojectstream__unpack_cache( \
     }
     astore__chdir(store, "..");
 
-    # *Unknonwn5 DWORD Length (2 bytes)
+    # *Unknown5 DWORD Length (2 bytes)
     _v = _count = stream__read_uint16(stream);
     if (astore__set(store, "*Unknown5 DWORD Length", _v) < 0) {
         return __vba__vbaprojectstream__E_UNEXPECTED;
     }
 
-    # *Unknonwn5 (variable)
+    # *Unknown5 (variable)
     astore__chdir(store, "*Unknown5");
     for (_i = 1; _i <= _count; ++_i) {
         _v = stream__read_hex_string(stream, 4);
@@ -24038,7 +24038,7 @@ __vba__vbaprojectstream__unpack_cache( \
     }
     astore__chdir(store, "..");
 
-    # *Unknonwn5 (2 bytes)
+    # *Unknown5 (2 bytes)
     _v = stream__read_hex_string(stream, 2);
     if (astore__set(store, "*Unknown6", _v) < 0) {
         return __vba__vbaprojectstream__E_UNEXPECTED;
@@ -24269,7 +24269,7 @@ __vba__vbaprojectstream__unpack_cache( \
 # +---------------------------------------------------------------+
 # |                              ...                              |
 # +---------------------------------------------------------------+
-# |                  Unknwon1 (6bytes, optional)                  |
+# |                  Unknown1 (6bytes, optional)                  |
 # +-------------------------------+-------------------------------+
 # |              ...              |     *Unknown2 (10 bytes)      |
 # +-------------------------------+-------------------------------+
@@ -24707,7 +24707,7 @@ __vba__vbaprojectstream__unpack_cachedjunkidentifier( \
 # +---------------------------------------------------------------+
 # |                              ...                              |
 # +-------------------------------+-------------------------------+
-# |   *Hash (2 bytes, optional)   | *Unkonwn3 (4 bytes, optional) |
+# |   *Hash (2 bytes, optional)   | *Unknown3 (4 bytes, optional) |
 # +-------------------------------+-------------------------------+
 #
 # '}'
@@ -26362,7 +26362,7 @@ forms20__unpack_commandbuttondatablock( \
         #
         # [MS-OFORMS] 2.5.31 ForeColor
         #
-        # the defalut value(CommandButton) is COLOR_BTNTEXT (0x80000012)
+        # the default value(CommandButton) is COLOR_BTNTEXT (0x80000012)
         #
         # '}'
         astore__fork(store, "ForeColor::OLE_COLOR", _store);
@@ -26379,7 +26379,7 @@ forms20__unpack_commandbuttondatablock( \
         #
         # [MS-OFORMS] 2.5.3 BackColor
         #
-        # the defalut value(CommandButton) is COLOR_BTNFACE (0x8000000f)
+        # the default value(CommandButton) is COLOR_BTNFACE (0x8000000f)
         #
         # '}'
         astore__fork(store, "BackColor::OLE_COLOR", _store);
@@ -26954,7 +26954,7 @@ forms20__unpack_labeldatablock( \
         #
         # [MS-OFORMS] 2.5.31 ForeColor
         #
-        # the defalut value(Label) is COLOR_BTNTEXT (0x80000012)
+        # the default value(Label) is COLOR_BTNTEXT (0x80000012)
         #
         # '}'
         astore__fork(store, "ForeColor::OLE_COLOR", _store);
@@ -26971,7 +26971,7 @@ forms20__unpack_labeldatablock( \
         #
         # [MS-OFORMS] 2.5.3 BackColor
         #
-        # the defalut value of Label is COLOR_BTNFACE (0x8000000f)
+        # the default value of Label is COLOR_BTNFACE (0x8000000f)
         #
         # '}'
         astore__fork(store, "BackColor::OLE_COLOR", _store);
@@ -27705,7 +27705,7 @@ forms20__unpack_formdatablock( \
         #
         # [MS-OFORMS] 2.5.3 BackColor
         #
-        # the defalut value(user form) is COLOR_BTNFACE (0x8000000f)
+        # the default value(user form) is COLOR_BTNFACE (0x8000000f)
         #
         # '}'
         astore__fork(store, "BackColor::OLE_COLOR", _store);
@@ -27722,7 +27722,7 @@ forms20__unpack_formdatablock( \
         #
         # [MS-OFORMS] 2.5.31 ForeColor
         #
-        # the defalut value(user form) is COLOR_BTNTEXT (0x80000012)
+        # the default value(user form) is COLOR_BTNTEXT (0x80000012)
         #
         # '}'
         astore__fork(store, "ForeColor::OLE_COLOR", _store);
@@ -27914,7 +27914,7 @@ forms20__unpack_formdatablock( \
         #
         # [MS-OFORMS] 2.5.7 BorderColor
         #
-        # the defalut value(user form) is COLOR_BTNTEXT (0x80000012)
+        # the default value(user form) is COLOR_BTNTEXT (0x80000012)
         #
         astore__fork(store, "BorderColor::OLE_COLOR", _store);
         _r = forms20__unpack_olecolor(stream, _store);
@@ -30470,7 +30470,7 @@ forms20__unpack_olecolor( \
 # +---------------+---------------+---------------+---------------+
 # |            sWeight            |            ulHeight           |
 # +-------------------------------+---------------+---------------+
-# |              ...              |   bFaseLen    |   FontFace    |
+# |              ...              |   bFaceLen    |   FontFace    |
 # |                               |               |  (variable)   |
 # +-------------------------------+---------------+---------------+
 # |                              ...                              |
@@ -31154,7 +31154,7 @@ forms20__unpack_formscrollbarflags( \
 # |               |                      | AutoWordSelect         |
 # |               |                      | HideSelection          |
 # |---------------+----------------------+------------------------+
-# | CommandButtonn| 0x0000001B           | Reserved1              |
+# | CommandButton | 0x0000001B           | Reserved1              |
 # | Image         |                      | Enabled                |
 # | TabStrip      |                      | BackStyle              |
 # | ScrollBar     |                      | Reserved2              |
@@ -31697,7 +31697,7 @@ cli__main( \
     "printf \\\\0\\\\r\\\\n\\\\343\\\\201\\\\202" | getline _test;
     __feat__is_binary_safe = length(_test) == 6;
 
-    # flags for optimization and portabilty
+    # flags for optimization and portability
     if (split("123", _arr, "") == 3) {
         __feat__has_modern_nullsplit = 1;
     }

--- a/hsvba
+++ b/hsvba
@@ -1,6 +1,6 @@
 #!/usr/bin/env LANG=C awk -f
 #
-#   ██╗  ██╗███████╗██╗   ██╗██████╗  █████╗ 
+#   ██╗  ██╗███████╗██╗   ██╗██████╗  █████╗
 #   ██║  ██║██╔════╝██║   ██║██╔══██╗██╔══██╗
 #   ███████║███████╗██║   ██║██████╔╝███████║
 #   ██╔══██║╚════██║╚██╗ ██╔╝██╔══██╗██╔══██║
@@ -28,7 +28,7 @@
 #  basic usage:
 #
 #    $ hsvba -- [-p <switches>] <file1> <file2> ...
-#    $ hsvba <file1> <file2> ... [-p <switches>] 
+#    $ hsvba <file1> <file2> ... [-p <switches>]
 #
 #  or input via stdin,
 #
@@ -376,27 +376,27 @@ BEGIN {
 #=# TRACE(t) {
 #=#     printf t > E__file;
 #=# }
-#=# 
+#=#
 #=# function \
 #=# TRACE1(t, arg1) {
 #=#     printf t, arg1 >> E__file;
 #=# }
-#=# 
+#=#
 #=# function \
 #=# TRACE2(t, arg1, arg2) {
 #=#     printf t, arg1, arg2 >> E__file;
 #=# }
-#=# 
+#=#
 #=# function \
 #=# TRACE3(t, arg1, arg2, arg3) {
 #=#     printf t, arg1, arg2, arg3 >> E__file;
 #=# }
-#=# 
+#=#
 #=# function \
 #=# TRACE4(t, arg1, arg2, arg3, arg4) {
 #=#     printf t, arg1, arg2, arg3, arg4 >> E__file;
 #=# }
-#=# 
+#=#
 #=# function \
 #=# TRACE5(t, arg1, arg2, arg3, arg4, arg5) {
 #=#     printf t, arg1, arg2, arg3, arg4, arg5 > E__file;
@@ -2434,7 +2434,7 @@ function map__insert( \
             if (_status < 0) {
                 return _status;
             }
-            return cell__C_err_success;    
+            return cell__C_err_success;
         }
     }
 
@@ -2501,7 +2501,7 @@ function map__insert( \
         return _status;
     }
 
-    return cell__C_err_success;    
+    return cell__C_err_success;
 }
 # }}}
 # {{{ (private)::map::fixup
@@ -2562,7 +2562,7 @@ function __map__fixup( \
 
                 # if (node == left(parent(node))
                 if (node == _v) {
-                    #         
+                    #
                     #                       +----+                     +----+
                     #                       | p3 |                     | p3 |
                     #                       +--*-+                     +--*-+
@@ -2580,13 +2580,13 @@ function __map__fixup( \
                     #               +--*--+                  +--*----+ +--*--+
                     #                 / \                      / \       / \
                     #                /   \                    /   \     /   \
-                    #               /     \                            /      
+                    #               /     \                            /
                     #         +----*--+ +--*--+                    +--*--+
                     #         |node(R)| |q1(B)|                    |q1(B)|
                     #         +---*---+ +--*--+                    +--*--+
                     #            / \      / \                        / \
                     #           /   \    /   \                      /   \
-                    #        
+                    #
 
                     # rotation patern LL
                     # get p3
@@ -2704,7 +2704,7 @@ function __map__fixup( \
                     }
 
                 } else {
-                    # 
+                    #
                     #               +----+                         +----+
                     #               | p3 |                         | p3 |
                     #               +--*-+                         +--*-+
@@ -2723,10 +2723,10 @@ function __map__fixup( \
                     #         / \                          /             \
                     #        /   \                     +--*--+         +--*--+
                     #             \                    |p1(B)|         |p2(B)|
-                    #           +--*----+              +--*--+         +--*--+      
-                    #           |node(R)|                / \             / \    
-                    #           +----*--+               /   \           /   \   
-                    #               / \                      \         /     
+                    #           +--*----+              +--*--+         +--*--+
+                    #           |node(R)|                / \             / \
+                    #           +----*--+               /   \           /   \
+                    #               / \                      \         /
                     #              /   \                   +--*--+ +--*--+
                     #             /     \                  |q1(B)| |q2(B)|
                     #         +--*--+ +--*--+              +--*--+ +--*--+
@@ -2894,7 +2894,7 @@ function __map__fixup( \
 
                 # if (node == left(parent(node))
                 if (node == _v) {
-                    #         
+                    #
                     #               +----+                             +----+
                     #               | p3 |                             | p3 |
                     #               +--*-+                             +--*-+
@@ -2907,16 +2907,16 @@ function __map__fixup( \
                     #             / \                                / \
                     #            /   \         rotate(RL)           /   \
                     #                 \             =>             /     \
-                    #               +--*--+                       /       \             
-                    #               |p1(R)|                      /         \         
-                    #               +--*--+                     /           \        
-                    #                 / \                      /             \       
-                    #                /   \                 +--*--+         +--*--+   
-                    #               /                      |p2(B)|         |p1(B)|   
-                    #         +----*--+                    +--*--+         +--*--+   
-                    #         |node(R)|                      / \             / \     
-                    #         +---*---+                     /   \           /   \     
-                    #            / \                             \         /     
+                    #               +--*--+                       /       \
+                    #               |p1(R)|                      /         \
+                    #               +--*--+                     /           \
+                    #                 / \                      /             \
+                    #                /   \                 +--*--+         +--*--+
+                    #               /                      |p2(B)|         |p1(B)|
+                    #         +----*--+                    +--*--+         +--*--+
+                    #         |node(R)|                      / \             / \
+                    #         +---*---+                     /   \           /   \
+                    #            / \                             \         /
                     #           /   \                          +--*--+ +--*--+
                     #          /     \                         |q1(B)| |q2(B)|
                     #      +--*--+ +--*--+                     +--*--+ +--*--+
@@ -3085,7 +3085,7 @@ function __map__fixup( \
                     # }}}
 
                 } else {
-                    #         
+                    #
                     #               +----+                             +----+
                     #               | p3 |                             | p3 |
                     #               +--*-+                             +--*-+
@@ -3101,15 +3101,15 @@ function __map__fixup( \
                     #               +--*--+                    +--*--+ +--*----+
                     #               |p1(R)|                    |p2(B)| |node(B)|
                     #               +--*--+                    +--*--+ +----*--+
-                    #                 / \                        / \       / \       
-                    #                /   \                      /   \     /   \      
-                    #               /     \                          \               
-                    #           +--*--+ +--*----+                  +--*--+                   
-                    #           |q1(B)| |node(R)|                  |q1(B)|                   
-                    #           +--*--+ +---*---+                  +--*--+                    
-                    #             / \      / \                       / \           
-                    #            /   \    /   \                     /   \       
-                    #                                                         
+                    #                 / \                        / \       / \
+                    #                /   \                      /   \     /   \
+                    #               /     \                          \
+                    #           +--*--+ +--*----+                  +--*--+
+                    #           |q1(B)| |node(R)|                  |q1(B)|
+                    #           +--*--+ +---*---+                  +--*--+
+                    #             / \      / \                       / \
+                    #            /   \    /   \                     /   \
+                    #
 
                     # rotation patern RR
                     # get p3
@@ -3236,7 +3236,7 @@ function __map__fixup( \
         }
     }
 
-    return cell__C_err_success;    
+    return cell__C_err_success;
 }
 # }}}
 # {{{ map::at
@@ -3723,7 +3723,7 @@ function __map__ut__01(    _key, _count, _keys, _i, _status, _t1, _t2, _a, _map,
 #
 # syntax of declare() DSL
 #
-#     definition = "atom" , <header> , "{", <body> "}" ; 
+#     definition = "atom" , <header> , "{", <body> "}" ;
 #
 #     header = <type> , ":" , <type_with_validation> ;
 #
@@ -5068,7 +5068,7 @@ __atom__type_new( \
 #       0: RAW
 #       1: RAW-HEX
 #       2: ANSI
-#       3: UNICODE 
+#       3: UNICODE
 #
 # Size:
 #   An integer size if D(SizeIsParameterized) is 0.
@@ -5081,7 +5081,7 @@ __atom__type_new( \
 #   Reference index of format string if D(SizeIsParameterized) is 0.
 #   Otherwize, this is a GOT address of ParameterizedFormat.
 #
-# Encoding: 
+# Encoding:
 #
 function \
 __atom__type_pack( \
@@ -5574,7 +5574,7 @@ __atom__eval( \
         E__message = "logic error(eval/rhs), tag: " _tag;
         return atom__errno = (-1);
     }
- 
+
     if (_tag == __atom__C_tag_cat) {
         _v = addr__ref(_lhs _rhs);
         if (_v < 0) {
@@ -5842,7 +5842,7 @@ astore__init(    _i, _status) {
     if (_status < 0) {
         return _status;
     }
- 
+
     # '${__pp_comment:+'
     #
     # SysKind (4 bytes):
@@ -6907,7 +6907,7 @@ astore__pretty_print( \
 #    |      <map>      |
 #    |     members     |
 #    +-----------------+
-# 
+#
 # '${__pp_ut__struct__:+"$(cut -d\# -f2-<<<'
 # BEGIN {
 #   _status = struct__ut();
@@ -7434,8 +7434,8 @@ __struct__parse( \
     # +-|-+---+   +-|-+---+   +-|-+---+   +-|-+---+       +---+---+
     #   v           v           v           v
     #  <integer>  <map>       <map>       <map>
-    #  n_params   binded      rmap      attribute 
-    #                                     
+    #  n_params   binded      rmap      attribute
+    #
     #
     # layout of struct
     #
@@ -7450,10 +7450,10 @@ __struct__parse( \
     #    +-----------------+
     #    |      <map>      |  reverse index
     #    |      rmap       |  {arg1:1, arg2:2, arg3:3}
-    #    +-----------------+  
-    #    |     <list>      |  
+    #    +-----------------+
+    #    |     <list>      |
     #    |     members     |  [ map1, map2, map3 ... ]
-    #    +-----------------+  
+    #    +-----------------+
     #
     #
     # '${__pp_comment:+'
@@ -7478,7 +7478,7 @@ __struct__parse( \
     # expression = <logicalOrExpression>
     #            |  "(" <expression> ")"
     #            ;
-    #           
+    #
     # logicalExpression = <logicalAndExpression>
     #                   , { ( "and" | "or" ) ,  <equalityExpression> }
     #                   ;
@@ -7507,7 +7507,7 @@ __struct__parse( \
     # uneryExpression := <primaryExpression>
     #                  | { ( "+" | "-" | "not" ) , <uneryExpression> } ;
     #
-    # primaryExpression := <variable> 
+    # primaryExpression := <variable>
     #                   |  <path>
     #                   |  <digits>
     #                   ;
@@ -8220,14 +8220,14 @@ __struct__parse( \
 #    +-----------------+
 #    |      <map>      |  reverse parameter map
 #    |      rmap       |  {arg1:1, arg2:2, arg3:3}
-#    +-----------------+  
-#    |     <list>      |  list of member 
+#    +-----------------+
+#    |     <list>      |  list of member
 #    |     members     |  [ member1, member2, member3 ... ]
-#    +-----------------+  
-#                       
-#                     
-# layout of member    
-#                       
+#    +-----------------+
+#
+#
+# layout of member
+#
 #    +-----------------+
 #    |    <binary>     |
 #    |     header      |
@@ -8313,10 +8313,10 @@ struct__type__init( \
 #    +-----------------+
 #    |      <map>      |  reverse index
 #    |      rmap       |  {arg1:1, arg2:2, arg3:3, arg4:4}
-#    +-----------------+  
-#    |     <list>      |  
+#    +-----------------+
+#    |     <list>      |
 #    |     members     |  [ map1, map2, map3 ... ]
-#    +-----------------+  
+#    +-----------------+
 #
 function \
 struct__type__new(    _p, _type, _v) {
@@ -21938,7 +21938,7 @@ __vba__dirstream__unpack_project_modules_module_readonly( \
 }
 # }}}
 # {{{ [MS-OVBA] 2.3.4.2.3.2.10 MODULEPRIVATE Record
-# 
+#
 # +===============================================================+
 # |                    1                   2                   3  |
 # |0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1|


### PR DESCRIPTION
@saitoha I was just curious and looked at the header comment block (as suggested on README), and I found spelling mistakes. I decided to scan through the source code. These are rather trivial ones, which I believe shouldn't have an impact on the behavior.
