### PR TITLE
Remove unused local variables

### DIFF
--- a/hsvba
+++ b/hsvba
@@ -1082,13 +1082,13 @@ function \
 stream__search( \
     stream, word, \
     \
-    _i, _buf, _len, _c, _it, _it_begin, _it_end \
+    _i, _buf, _len, _c, _it, _it_end \
 ) {
     _len = length(word);
     for (_i = 1; _i <= _len; ++_i) {
         _buf[_i] = str__ord[substr(word, _i, 1)];
     }
-    _it = _it_begin = stream[__stream__M_iit];
+    _it = stream[__stream__M_iit]; # _it_begin
     _it_end = stream[__stream__M_oit];
     _c = _buf[1];
     for (_i = 1; _i <= _len && _it <= _it_end; ) {
@@ -1244,10 +1244,10 @@ function \
 stream__write_bits( \
     stream, n, data, \
     \
-    _it, _it_bits, _bits, _bitsbuf \
+    _it, _bits, _bitsbuf \
 ) {
     _it = stream[__stream__M_oit];
-    _it_bits = _bits = stream[__stream__M_obit];
+    _bits = stream[__stream__M_obit]; # _it_bits
     _bitsbuf = stream[_it + 1] % (2 ^ _bits) + data * (2 ^ _bits);
     _bits += n;
     if (_bits >= 8) {
@@ -7761,7 +7761,7 @@ __struct__parse( \
     \
     _v, _stack, _count, _i, _token, _pos, _key, _map, _list, \
     _tokid, _position, _tail, _typename, _type, _type_m, \
-    _stem, _n, _struct_name, _params, _rmap, _index, _x, \
+    _n, _struct_name, _params, _rmap, _index, _x, \
     _status, _member, _pos1, _pos2 \
 ) {
     # current parser state
@@ -7912,7 +7912,7 @@ __struct__parse( \
         } else if (__struct__S_pst == __struct__C_pst_struct) {
             # {{{
             if (_tokid == __struct__C_tok_identifier) {
-                _struct_name = _stem = addr__deref(_tail);
+                _struct_name = addr__deref(_tail); # _stem
                 if (addr__errno < 0) {
                     break;
                 }
@@ -16403,9 +16403,7 @@ __zlib__inflate__compressed_content( \
     distance_huffman_table, \
     ostream, \
     \
-    _length, _distance, \
-    _extra_distance, _extra_bits, \
-    _code, _st \
+    _length, _distance, _extra_bits, _code, _st \
 ) {
     # '${__pp_comment:+'
     #
@@ -16529,7 +16527,7 @@ __zlib__inflate__compressed_content( \
             _distance = __zlib__C_DEFLATE_LZ77_DISTANCE[_code + 1];
             _extra_bits = __zlib__C_LZ77_DISTANCE_EXTEND_BITS[_code + 1]
             if (_extra_bits > 0) {
-                _distance += _extra_distance = stream__read_bits(istream, _extra_bits);
+                _distance += stream__read_bits(istream, _extra_bits); # add _extra_distance
             }
 
             #=# '${__pp_trace__zip_debug3+"$(cut -d\# -f3-<<<'
@@ -18611,7 +18609,7 @@ pcode__disasm_var( \
     pcode, stream, store, dword, optype, opcode, \
     \
     _v, _jmp_buf_op, _text, _flag1, _flag2, _has_as, _has_new, \
-    _offset, _typename, _varname \
+    _offset, _typename \
 ) {
     stream__setjmp(stream, _jmp_buf_op);
     stream__iseek(stream, pcode__get_idt_offset(pcode) + 4 + dword);
@@ -18624,7 +18622,7 @@ pcode__disasm_var( \
 
     _has_as = num__and(_flag1, 32);
     _has_new = num__and(_flag2, 32);
-    _v = _varname = pcode__getname(pcode, stream, store);
+    _v = pcode__getname(pcode, stream, store); # _var_name
     astore__set(store, "Name", _v);
 
     _text = _v;
@@ -20770,7 +20768,7 @@ function \
 __vba__dirstream__unpack_project_information_lcid( \
     stream, store, \
     \
-    _v, _size \
+    _v \
 ) {
     # Id (2 bytes)
     _v = stream__read_uint16(stream);
@@ -20779,7 +20777,7 @@ __vba__dirstream__unpack_project_information_lcid( \
     }
 
     # Size (4 bytes)
-    _v = _size = stream__read_uint32(stream);
+    _v = stream__read_uint32(stream); # _size
     if (astore__set(store, "Size::uint32,mustbe(4)", _v) < 0) {
         return vba__dirstream__E_UNEXPECTED;
     }
@@ -21975,11 +21973,11 @@ function \
 __vba__dirstream__unpack_project_modules( \
     stream, store, \
     \
-    _v, _id, _r, _i, \
+    _v, _r, _i, \
     _count, _store, _left \
 ) {
     # Id (2 bytes)
-    _v = _id = stream__read_uint16(stream);
+    _v = stream__read_uint16(stream); # _id
     if (astore__set(store, "Id::VBAMagic,mustbe(15)", _v) < 0) {
         return vba__dirstream__E_UNEXPECTED;
     }
@@ -22035,10 +22033,10 @@ function \
 __vba__dirstream__unpack_project_modules_cookie( \
     stream, store, \
     \
-    _v, _id \
+    _v \
 ) {
     # Id (2 bytes)
-    _v = _id = stream__read_uint16(stream);
+    _v = stream__read_uint16(stream); # _id
     if (astore__set(store, "Id::VBAMagic,mustbe(19)", _v) < 0) {
         return vba__dirstream__E_UNEXPECTED;
     }
@@ -25411,7 +25409,7 @@ function \
 __vba__vbaprojectstream__unpack_cachedidentifier( \
     stream, store, \
     \
-    _v, _type_and_length, _length, _is_keyword, _name \
+    _v, _type_and_length, _length, _is_keyword \
 ) {
     _is_keyword = 0;
 
@@ -25445,7 +25443,7 @@ __vba__vbaprojectstream__unpack_cachedidentifier( \
 
     # the low byte of _type_and_length indicates the length
     if ((_length = _type_and_length % 256) != 0) {
-        _v = _name = stream__read_ansi_string(stream, _length);
+        _v = stream__read_ansi_string(stream, _length); # _name
         if (astore__set(store, "*Name", _v) < 0) {
             return __vba__vbaprojectstream__E_UNEXPECTED;
         }


### PR DESCRIPTION
This PR attempts to remove variables that are assigned but not referenced later.

- 9d1c08cb965c5e95a126723a2cd22459ce793248 and 127d9401048790d7e3c0f1394f8a21fc51079eeb remove unused local variable declarations. If some of them are actually intended for the future use in the function, please let me know. I'll drop the specified changes. Actually, `__list__ut__01` and `__list__walk_impl` also declare many unused local variables, but I left them as is because I guessed these are stub for the future implementation.
- The third commit 73ceea8abb296e6cf10d4d1590652ab60bedb19d simply removes unused variables.
- The fourth commit bf2db4a600d7352c99731c01618b3897d0c4560d rewrites the pattern `_v = _name = expression;` (where `_name` is never used elsewhere) to simply `_v = expression; # _name`. However, this might be intentionally used to give a *name* to the expression on the right-hand side. If so, please let me know. I can drop the commit, or maybe it is better to rewrite these to `_name = expression; _v = _name;` for the clarity.


Note: This is not a complete list of variables that are assigned but never used elsewhere. These are found by applying a spell checker to the body of each function and examining variables appearing only once in the function.

